### PR TITLE
Improve bin scripts

### DIFF
--- a/bin/createNavData.js
+++ b/bin/createNavData.js
@@ -1,7 +1,6 @@
 const fse = require('fs-extra');
-const { Observable } = require('rx');
 
-const { commonREs, info, readDir, pagesDir } = require('../utils');
+const { commonREs, info, readDir, loopPages } = require('../utils');
 
 const { isAStubRE, metaTitleRE } = commonREs;
 
@@ -24,67 +23,56 @@ function getPageTitle(content, path) {
   }
 }
 
-function listAllDirs(level, prevPages = []) {
-  let accuPages = [...prevPages];
-  return Observable.from(readDir(level)).flatMap(parentDir => {
-    const dirPath = `${level}/${parentDir}`;
-    const filePath = `${dirPath}/index.md`;
-    const content = readIndex(filePath);
-    const subDirs = readDir(dirPath);
-    const parent = level.split('/')[level.split('/').length - 1];
-    const title = getPageTitle(content, filePath);
-    const isStubbed = isAStubRE.test(content);
-    // remove 'src/pages' from the path
-    const articlePath = dirPath.slice(9);
+function addPage(dirPath, name) {
+  const filePath = `${dirPath}/index.md`;
+  const content = readIndex(filePath);
+  const subDirs = readDir(dirPath);
+  const title = getPageTitle(content, filePath);
+  const isStubbed = isAStubRE.test(content);
+  const parent = dirPath.split('/')[dirPath.split('/').length - 2];
+  // remove 'src/pages' from the path
+  const articlePath = dirPath.slice(9);
 
-    navData[articlePath] = {
-      children: subDirs.map(title => title.toLowerCase()),
-      dashedName: parentDir.toLowerCase(),
-      hasChildren: !!subDirs.length,
-      isStubbed,
-      path: articlePath,
-      parent,
-      parentPath: level.slice(9).replace(new RegExp(parent + '/'), ''),
-      title
-    };
-    if (!subDirs.length) {
-      // no child directories
-      return Observable.of(null);
+  navData[articlePath] = {
+    children: subDirs.map(title => title.toLowerCase()),
+    dashedName: name.toLowerCase(),
+    hasChildren: !!subDirs.length,
+    isStubbed,
+    path: articlePath,
+    parent,
+    parentPath: articlePath.replace(new RegExp(parent + '/'), ''),
+    title
+  };
+}
+
+
+info('Creating navData...', 'yellow');
+const startTime = Date.now();
+
+loopPages(addPage)
+  .toArray()
+  .subscribe(
+    () => {},
+    err => {
+      throw err;
+    },
+    () => {
+      fse
+        .writeFile(
+          `${process.cwd()}/src/navData.json`,
+          JSON.stringify(navData, null, 2)
+        )
+        .then(() => {
+          const msTaken = Date.now() - startTime;
+          const pages = Object.keys(navData).length;
+          info('navData created', 'greenBright');
+          info(
+            `It took ${msTaken}ms to create the navData for ${pages} pages`,
+            'yellow'
+          );
+        })
+        .catch(err => {
+          throw err;
+        });
     }
-    return listAllDirs(dirPath, accuPages);
-  });
-}
-
-function createNavData() {
-  info('Creating navData...', 'yellow');
-  const startTime = Date.now();
-  listAllDirs(pagesDir, [])
-    .toArray()
-    .subscribe(
-      () => {},
-      err => {
-        throw err;
-      },
-      () => {
-        fse
-          .writeFile(
-            `${process.cwd()}/src/navData.json`,
-            JSON.stringify(navData, null, 2)
-          )
-          .then(() => {
-            const msTaken = Date.now() - startTime;
-            const pages = Object.keys(navData).length;
-            info('navData created', 'greenBright');
-            info(
-              `It took ${msTaken}ms to create the navData for ${pages} pages`,
-              'yellow'
-            );
-          })
-          .catch(err => {
-            throw err;
-          });
-      }
-    );
-}
-
-createNavData();
+  );

--- a/bin/normaliseArticles.js
+++ b/bin/normaliseArticles.js
@@ -1,7 +1,6 @@
 const fse = require('fs-extra');
-const { Observable } = require('rx');
 
-const { commonREs, titleify, info, readDir, pagesDir } = require('../utils');
+const { commonREs, titleify, info, loopPages } = require('../utils');
 
 const { httpsRE, isAStubRE, markdownLinkRE } = commonREs;
 
@@ -43,20 +42,20 @@ function normaliseLinks(content) {
   const links = content.match(markdownLinkRE);
 
   if (links) {
-  links
-    .filter(x => !x.startsWith('!'))
-    .filter(x => x.match(httpsRE))
-    .map(str => {
-      // raw will look like: 
-      // [ '[guides website', 'https://guide.freecodecamp.org)' ]
-      const raw = str.slice(0).split('](');
-      const formatted = [ raw[0].replace('[', ''), raw[1].replace(')', '') ];
-      const [ childText, url ] = formatted;
-      const anchor = (
-        `<a href='${url}' target='_blank' rel='nofollow'>${childText}</a>`
-      );
-      anchored = anchored.replace(str, anchor);
-    });
+    links
+      .filter(x => !x.startsWith('!'))
+      .filter(x => x.match(httpsRE))
+      .map(str => {
+        // raw will look like: 
+        // [ '[guides website', 'https://guide.freecodecamp.org)' ]
+        const raw = str.slice(0).split('](');
+        const formatted = [ raw[0].replace('[', ''), raw[1].replace(')', '') ];
+        const [ childText, url ] = formatted;
+        const anchor = (
+          `<a href='${url}' target='_blank' rel='nofollow'>${childText}</a>`
+        );
+        anchored = anchored.replace(str, anchor);
+      });
   }
 
   return anchored;
@@ -103,30 +102,13 @@ function normalise(dirLevel) {
   });
 }
 
-function applyNormaliser(dirLevel) {
-  return Observable.from(readDir(dirLevel))
-    .flatMap(dir => {
-      const dirPath = `${dirLevel}/${dir}`;
-      const subDirs = readDir(dirPath);
-      if (!subDirs) {
-        normalise(dirPath);
-        return Observable.of(null);
-      }
-      normalise(dirPath);
-      return applyNormaliser(dirPath);
-    });
-}
-
-applyNormaliser(pagesDir)
-  .subscribe((dir)=> {
-    if (dir) {
-      applyNormaliser(dir);
-    }
-  },
-  err => {
+loopPages(normalise)
+  .subscribe(
+    () => {},
+    err => {
       throw err;
     },
     () => {
-      info('\n\nNormalisation Completed\n\n', 'greenBright');
+      info('\nNormalisation Completed', 'greenBright');
       info('Please check for uncommited changes before pushing\n', 'yellow');
     });

--- a/bin/normaliseArticles.js
+++ b/bin/normaliseArticles.js
@@ -2,7 +2,7 @@ const fse = require('fs-extra');
 
 const { commonREs, titleify, info, loopPages } = require('../utils');
 
-const { httpsRE, isAStubRE, markdownLinkRE } = commonREs;
+const { isAStubRE, markdownLinkRE } = commonREs;
 
 function appendStub(path) {
   const pathArr = path.split('/');
@@ -38,27 +38,11 @@ This is a stub. [Help our community expand it](https://github.com/freecodecamp/g
 /* eslint-enable max-len */
 
 function normaliseLinks(content) {
-  let anchored = content.slice(0);
-  const links = content.match(markdownLinkRE);
-
-  if (links) {
-    links
-      .filter(x => !x.startsWith('!'))
-      .filter(x => x.match(httpsRE))
-      .map(str => {
-        // raw will look like: 
-        // [ '[guides website', 'https://guide.freecodecamp.org)' ]
-        const raw = str.slice(0).split('](');
-        const formatted = [ raw[0].replace('[', ''), raw[1].replace(')', '') ];
-        const [ childText, url ] = formatted;
-        const anchor = (
-          `<a href='${url}' target='_blank' rel='nofollow'>${childText}</a>`
-        );
-        anchored = anchored.replace(str, anchor);
-      });
-  }
-
-  return anchored;
+  return content.replace(markdownLinkRE, (match, before, text, url) => {
+    return markdownLinkRE.test(text) ? match : (
+      `${before}<a href='${url}' target='_blank' rel='nofollow'>${text}</a>`
+    );
+  });
 }
 
 function normalise(dirLevel) {

--- a/src/pages/certificates/diff-two-arrays/index.md
+++ b/src/pages/certificates/diff-two-arrays/index.md
@@ -64,8 +64,8 @@ The best way to go about the callback function is to check if the number from th
     }
 
     diffArray([1, 2, 3, 5], [1, 2, 3, 4, 5]);
-```
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href="https://repl.it/CLme/0">Run Code</a>
+
+<a href='https://repl.it/CLme/0' target='_blank' rel='nofollow'><kbd>![](//discourse-user-assets.s3.amazonaws.com/original/2X/6/6d6bf8d908c0577924495e89482c7163190c3856.png) **Run Code** ![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:")</kbd></a>
 
 ### Code Explanation:
 
@@ -87,7 +87,8 @@ Read the comments in the code.
 
     diffArray([1, 2, 3, 5], [1, 2, 3, 4, 5]);
 ```
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href="https://repl.it/CNYb/0">Run Code</a>
+
+<a href='https://repl.it/CNYb/0' target='_blank' rel='nofollow'><kbd>![](//discourse-user-assets.s3.amazonaws.com/original/2X/6/6d6bf8d908c0577924495e89482c7163190c3856.png) **Run Code** ![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:")</kbd></a>
 
 ### Code Explanation:
 
@@ -111,7 +112,7 @@ Explain solution here and add any relevant links
 
     diffArray([1, 2, 3, 5], [1, 2, 3, 4, 5]);
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href="https://repl.it/CNYU/0">Run Code</a>
+<a href='https://repl.it/CNYU/0' target='_blank' rel='nofollow'><kbd>![](//discourse-user-assets.s3.amazonaws.com/original/2X/6/6d6bf8d908c0577924495e89482c7163190c3856.png) **Run Code** ![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:")</kbd></a>
 
 ### Code Explanation:
 

--- a/src/pages/css/css-frameworks/css-framework-foundation/index.md
+++ b/src/pages/css/css-frameworks/css-framework-foundation/index.md
@@ -26,6 +26,7 @@ Here is a simple HTML template which includes the latest compiled and minified C
       </body>
     </html>
 ```
+ <kbd><a href='http://jsbin.com/gebolikiru/edit?html,output' target='_blank' rel='nofollow'>![](//discourse-user-assets.s3.amazonaws.com/original/2X/f/f9c81b35877c3e0551ca461c75b78aac80c6f48a.png) **JSBin Demo**</a></kbd>
 
 This example makes use of a CDN that loads the default settings. If you'd like to customize the grid layout, change the colors or add and remove components you can do so on the Foundation [download](http://foundation.zurb.com/sites/download/) page.
 

--- a/src/pages/css/css-frameworks/css-framework-skeleton/index.md
+++ b/src/pages/css/css-frameworks/css-framework-skeleton/index.md
@@ -26,7 +26,7 @@ Here is a simple HTML template which includes the latest compiled and minified C
       </body>
     </html>
 ```
- <kbd>[![](//discourse-user-assets.s3.amazonaws.com/original/2X/3/31bd555700f1ee85bb4ddcacf595f0dfd8a16254.png) **JSBin Demo**](http://jsbin.com/sekojaxali/edit?html,output)</kbd>
+ <kbd><a href='http://jsbin.com/sekojaxali/edit?html,output' target='_blank' rel='nofollow'>![](//discourse-user-assets.s3.amazonaws.com/original/2X/3/31bd555700f1ee85bb4ddcacf595f0dfd8a16254.png) **JSBin Demo**</a></kbd>
 
 We have used a CDN in this example, but you can checkout other ways of installing Skeleton <a href='https://github.com/dhg/Skeleton#getting-started' target='_blank' rel='nofollow'>here</a>.
 

--- a/src/pages/designer-tools/Experience-design/index.md
+++ b/src/pages/designer-tools/Experience-design/index.md
@@ -34,4 +34,4 @@ Why Prototyping with Adobe XD is the Most-Complete Design Solution: <a href='htt
 
 And here's a playlist of 36 videos to help you get started in Adobe XD: <a href='https://youtu.be/HqQtYIMnWhM' target='_blank' rel='nofollow'>Youtube</a>
 
-<a href='https://en.wikipedia.org/wiki/Adobe_Experience_Design target='_blank' rel='nofollow'>Adobe Experience Design wikipedia page</a>
+<a href='https://en.wikipedia.org/wiki/Adobe_Experience_Design' target='_blank' rel='nofollow'>Adobe Experience Design wikipedia page</a>

--- a/src/pages/meta/free-code-camps-august-live-stream/index.md
+++ b/src/pages/meta/free-code-camps-august-live-stream/index.md
@@ -18,4 +18,4 @@ title: Free Code Camps August Live Stream
 *   Closing from Quincy <a href='https://youtu.be/UhoxoYrJ6Qs?t=1h4m15s' target='_blank' rel='nofollow'>1:04:15</a>
 *   <a href='https://youtu.be/r0lCJ_TFYlI' target='_blank' rel='nofollow'>Pull Request After Party with Quincy</a>
 
-[![Screen shot from our twitch feed on August 1 2015](//discourse-user-assets.s3.amazonaws.com/original/2X/2/2630ba14f0dd558a01903fd81d4ebbb9309cb926.png)](http://www.youtube.com/watch?feature=player_embedded&v=UhoxoYrJ6Qs)
+<a href='http://www.youtube.com/watch?feature=player_embedded&v=UhoxoYrJ6Qs' target='_blank' rel='nofollow'>![Screen shot from our twitch feed on August 1 2015](//discourse-user-assets.s3.amazonaws.com/original/2X/2/2630ba14f0dd558a01903fd81d4ebbb9309cb926.png)</a>

--- a/src/pages/meta/free-code-camps-summit-august-2015/index.md
+++ b/src/pages/meta/free-code-camps-summit-august-2015/index.md
@@ -18,4 +18,4 @@ Free Code Camp's <a>August Live Stream</a> was the largest yet.
 *   Closing from Quincy <a href='https://youtu.be/UhoxoYrJ6Qs?t=1h4m15s' target='_blank' rel='nofollow'>1:04:15</a>
 *   <a href='https://youtu.be/r0lCJ_TFYlI' target='_blank' rel='nofollow'>Pull Request After Party with Quincy</a>
 
-[![Screen shot from our twitch feed on August 1 2015](//discourse-user-assets.s3.amazonaws.com/original/2X/a/ae495957ffa462d9cb26a59b9a4e79e8407a700c.png)](http://www.youtube.com/watch?feature=player_embedded&v=UhoxoYrJ6Qs)
+<a href='http://www.youtube.com/watch?feature=player_embedded&v=UhoxoYrJ6Qs' target='_blank' rel='nofollow'>![Screen shot from our twitch feed on August 1 2015](//discourse-user-assets.s3.amazonaws.com/original/2X/a/ae495957ffa462d9cb26a59b9a4e79e8407a700c.png)</a>

--- a/src/pages/miscellaneous/guide-to-build-a-sliding-image-gallery/index.md
+++ b/src/pages/miscellaneous/guide-to-build-a-sliding-image-gallery/index.md
@@ -3,7 +3,7 @@ title: Guide to Build a Sliding Image Gallery
 ---
 This tutorial will walk you through building an image slider using the <a href='https://jquery.com/' target='_blank' rel='nofollow'>jQuery</a> library.
 
-[![GIF showing Slider in action](//discourse-user-assets.s3.amazonaws.com/original/2X/0/08d83a22c28da836a06853b1f1ea669b398326b9.gif)](https://codepen.io/atjonathan/pen/BKMxxq)
+<a href='https://codepen.io/atjonathan/pen/BKMxxq' target='_blank' rel='nofollow'>![GIF showing Slider in action](//discourse-user-assets.s3.amazonaws.com/original/2X/0/08d83a22c28da836a06853b1f1ea669b398326b9.gif)</a>
 
 This tutorial will have four parts:  
 - [HTML](#html)  

--- a/utils/index.js
+++ b/utils/index.js
@@ -2,13 +2,12 @@ const titleify = require('./titleify');
 const commonREs = require('./regEx');
 const info = require('./infoLog');
 const readDir = require('./readDir');
-
-const pagesDir = 'src/pages';
+const loopPages = require('./loopPages');
 
 module.exports = {
   commonREs,
   titleify,
   info,
   readDir,
-  pagesDir
+  loopPages
 };

--- a/utils/loopPages.js
+++ b/utils/loopPages.js
@@ -2,19 +2,16 @@ const { Observable } = require('rx');
 
 const readDir = require('./readDir');
 
-// dir is the root pages directory
-// handler is a callback that receives
-// the full path to the page parent dir
-// and the name of the current dir
 module.exports = function loopPages(handler, dir = 'src/pages') {
-  return Observable.from(readDir(dir)).flatMap(articleParentDir => {
-    const path = `${dir}/${articleParentDir}`;
-    handler(path, articleParentDir);
+  return Observable.from(readDir(dir))
+    .flatMap(articleParentDir => {
+      const path = `${dir}/${articleParentDir}`;
+      handler(path, articleParentDir);
 
-    if (readDir(path)) {
-      return loopPages(handler, path);
-    }
+      if (readDir(path)) {
+        return loopPages(handler, path);
+      }
 
-    return Observable.of(null);
+      return Observable.of(null);
   });
 };

--- a/utils/loopPages.js
+++ b/utils/loopPages.js
@@ -1,0 +1,20 @@
+const { Observable } = require('rx');
+
+const readDir = require('./readDir');
+
+// dir is the root pages directory
+// handler is a callback that receives
+// the full path to the page parent dir
+// and the name of the current dir
+module.exports = function loopPages(handler, dir = 'src/pages') {
+  return Observable.from(readDir(dir)).flatMap(articleParentDir => {
+    const path = `${dir}/${articleParentDir}`;
+    handler(path, articleParentDir);
+
+    if (readDir(path)) {
+      return loopPages(handler, path);
+    }
+
+    return Observable.of(null);
+  });
+};

--- a/utils/regEx.js
+++ b/utils/regEx.js
@@ -1,12 +1,10 @@
-const httpsRE = /https?\:\/\//;
 const isAFileRE = /(\.md|\.jsx?|\.html?)$/;
 const isAStubRE = /This\sis\sa\sstub.+?Help\sour\scommunity\sexpand\sit/;
-const markdownLinkRE = /\!?\[.*?\]\(.+?\)/g;
-const metaTitleRE = /^---\r?\ntitle:([^\n]*)\n---$/m;
+const metaTitleRE = /^---\s*title:([^\n]*)\n---$/m;
+const markdownLinkRE = /([^!])\[([^\n]*)\]\((https?\:\/\/[^\n]*)\)/g;
 const shouldBeIgnoredRE = /^(\_|\.)/;
 
 module.exports = {
-  httpsRE,
   isAFileRE,
   isAStubRE,
   markdownLinkRE,


### PR DESCRIPTION
Another refactor of the bin scripts. They both had the same page loop done in a slightly different way. Now they both use the same page loop as a util. https://github.com/systimotic/guides/commit/54816bed35af6dcba1a860472dab587576c8dd0e

I also added a formatted error for when there is a missing `index.md`. https://github.com/systimotic/guides/commit/b6d5b485114e5bebd4fe9d0686046bc6b698522f

The final change in this PR changes the link normalization. https://github.com/systimotic/guides/commit/d86f9f94d7f52abb1027cb2389ccb795c242f3d6 Doing this convinced me switching to a plugin is absolutely the right thing to do. 
The new regex catches some things that previously weren't caught (examples in meta and misc image gallery).
It also doesn't break by thinking there are links that are spread out across multiple lines, which should help with some of the issues where links removed content.
It still has issues with multiple links on the same line. The ternary operator helps with this if there are more then two, but not if there are exactly two. Switching to a plugin would help massively with this, as we could use the AST instead of trying to parse using regular expressions.