### PR TITLE
Explain dropdown-menu-right class

### DIFF
--- a/src/pages/bootstrap/bootstrap-dropdowns/index.md
+++ b/src/pages/bootstrap/bootstrap-dropdowns/index.md
@@ -33,6 +33,8 @@ The *.caret* class creates a caret arrow icon (&#9660;), which indicates that th
 
 Add the *.dropdown-menu* class to a unordered list element to actually build the dropdown menu.
 
+Use *.dropdown-menu-right* instead of *.dropdown-menu* to right align the dropdown menu. 
+
 #### More Information:
 https://getbootstrap.com/docs/4.0/components/dropdowns/
 


### PR DESCRIPTION
Add an explanation that show the dropdown can be right-aligned by using the dropdown-menu-right class