### PR TITLE
Added stubs for gradient descent and optimization algorithms for gradient descent

### DIFF
--- a/src/pages/machine-learning/deep-learning/gradient-descent/index.md
+++ b/src/pages/machine-learning/deep-learning/gradient-descent/index.md
@@ -1,0 +1,15 @@
+---
+title: Gradient Descent
+---
+## Gradient Descent
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/machine-learning/deep-learning/gradient-descent/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+

--- a/src/pages/machine-learning/deep-learning/optimization-algorithms-for-gradient-descent/index.md
+++ b/src/pages/machine-learning/deep-learning/optimization-algorithms-for-gradient-descent/index.md
@@ -1,0 +1,15 @@
+---
+title: Optimization Algorithms for Gradient Descent
+---
+## Optimization Algorithms for Gradient Descent
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/machine-learning/deep-learning/optimization-algorithms-for-gradient-descent/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+


### PR DESCRIPTION
I think the guides are missing the important stuff of neural networks. So, added the stubs for gradient descent and optimization algorithms for gradient descent. Not sure, whether each of the optimization algorithms like Adam, Adagrad, rmsprop etc., should have their own sub-page or they go into the stub I just created.