### PR TITLE
Remove BDD reference from Ruby index

### DIFF
--- a/src/pages/ruby/index.md
+++ b/src/pages/ruby/index.md
@@ -6,9 +6,3 @@ title: Ruby
 Ruby is a programming language created to maximize developer happiness and readability. It is the high level scripting language that powers Ruby on Rails, which remains one of the more popular web development frameworks.
 
 Ruby was created by Yukihiro "Matz" Matsumoto with the goal of making Ruby "natural, not simple." Ruby is open source and free to use, copy, modify and distrubute. You can find the Ruby source code on <a href='https://github.com/ruby/ruby' target='_blank' rel='nofollow'>GitHub</a>.
-
-## Behaviour Driven Development BDD (RSpec)
-
-Behaviour Driven Development for Ruby. Making TDD Productive and Fun.
-More resoruces can be found here:
-http://rspec.info/


### PR DESCRIPTION
A discussion of BDD isn't appropriate for the Ruby index page.