### PR TITLE
Fix code block to display correctly in VIM Macros Page

### DIFF
--- a/src/pages/vim/macros/index.md
+++ b/src/pages/vim/macros/index.md
@@ -12,8 +12,8 @@ Macros use one of the VIM registers to be storage, each register is indentify by
 
 To start a Macro, in Normal Mode, press:
 
-```
-q<letter>
+```vim
+q<REGISTER LETTER>
 ```
 Example: `qq` starts a macro in the register `q`, `qs` starts the macro in the register `s`
 


### PR DESCRIPTION
In the code block bellow "To start a Macro, in Normal Mode, press:" the commnad shoud be `q<letter>`, but in the guide page, it renders as an html tag `<letter><letter/>` and it is not visible for the visitors, that only see `q`.
So I add an identifier on the block, and change the description, in the hope it displays correct in the guide.

<!--
Thanks for contributing to the freeCodeCamp Guide! Before you open your pull request (PR), please make sure to do the following:

- Avoid a duplicate PR: search through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes
- Your changes pass the Travis CI build: any new folder you create in "src/pages" must have an index.md. All articles must have the following as the first three lines in the file:

---
title: Title of the article that shows up in the site's menu
---

- If you edit a stub article, your changes are substantial enough to justify removing the stub text ("This article is a stub..." part). We can't accept PRs that only add links to the "More Information" section - a repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file
- Your PR has a descriptive name (NOT: Update index.md): for example, if you create a "Variables" article inside the "Python" directory, the pull request title should be "Python: add Variables article". Other examples are "Git: edit Git Commit article" or "PHP: create PHP section and add Data Structures article"
- Add a short description below describing your changes

-->

**Description**
