### PR TITLE
Agile: add Scrum Master article

### DIFF
--- a/src/pages/agile/scrummasters/index.md
+++ b/src/pages/agile/scrummasters/index.md
@@ -1,15 +1,36 @@
 ---
-title: Scrummasters
+title: Scrum Master
 ---
-## Scrummasters
+## Scrum Master
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/agile/scrummasters/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+The Scrum Master is responsible for making sure that Scrum is understood and
+enacted. He is the servant-leader for the Scrum Team, with the goal to help the
+team maximize the value created by the team.
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+The Scrum Master is responsible for:
+- the process
+- the team
+- continuous improvement of both
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+Typically the Scrum Master plans and facilitates all Scrum related meetings:
+- Daily Scrum
+- Sprint Planning
+- Sprint Review
+- Sprint Retrospective
+
+He knows and understands the Scrum process and agile mindset behind it. He has
+the authority over the process and ensures that the team adheres to it.
+
+He is responsible for removing impediments. An impediment is anything that keeps
+the team from getting work done and slows them down.
+
+The Scrum Master should also act as a coach to the team and the organization.
+
+It is important to note, that the Scrum Master is not a project manager or
+team lead!
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
+[Scrum.org - What is a Scrum Master] (https://www.scrum.org/resources/what-is-a-scrum-master)
 
 


### PR DESCRIPTION
Replacing the Scrum Master article stub with content and a link to more information.