### PR TITLE
Python: Add a snippet about virtual environments to 'Using Pip'

### DIFF
--- a/src/pages/python/using-pip/index.md
+++ b/src/pages/python/using-pip/index.md
@@ -1,7 +1,7 @@
 ---
 title: Python Using Pip
 ---
-We have seen how to use `import` statements to `import` various modules and to use them in our programs. Python itself comes with several built-in modules, but the python community has more to offer.
+We have seen how to use `import` statements to `import` various modules and to use them in our programs. Python itself comes with several built-in modules, but the Python community has more to offer.
 
 > Its the modules that makes python so powerful!
 
@@ -11,7 +11,9 @@ The simplest way is to use `pip`
 
     pip install <module_name>
 
-If you have used `npm`, then you can think of it as _npm_ of python.
+If you have used `npm`, then you can think of it as _npm_ of Python.
+
+Side note: The difference is that with npm, `npm install` by default installs packages locally to a project, whereas `pip install` by default installs globally.  To install modules locally, you need to create and activate what is called a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/), so `pip install` installs to the folder where that virtual environment is located, instead of globally (which may require administrator privileges).
 
 Last time, in <a>`import-statements`</a> wiki we used `requests` module as an example. As it is a third party module we have to install it separately after installing python.
 


### PR DESCRIPTION
I added a small snippet to the existing article making it clear that "pip install" by default installs globally, and so one should use a virtual environment, in contrast with "npm install" which by default installs globally.