### PR TITLE
create sections for simple styling and state links

### DIFF
--- a/src/pages/css/styling-links/index.md
+++ b/src/pages/css/styling-links/index.md
@@ -1,15 +1,57 @@
 ---
 title: Styling Links
 ---
+
 ## Styling Links
+Use the property `color` to specify the color of a link. The value can be one of the 140 color names, hexadecimal code or RGBA value.
+```
+a { 
+  color: RoyalBlue ;
+}
+```
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/css/styling-links/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+You can also set a background color with `background-color` and choose the underscore style with `text-decoration`.
+```
+a {
+  background-color: #191970;
+  text-decoration: none;
+ }
+ ```
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+## Styling States
+There are more ways to stylize link using the following pseudo-classes according to the link's state :
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+- `:link` for an unvisited link ;
+- `:visited` for a visited link ;
+- `:hover` for the style of a link when the mouse is over it ;
+- `:active` for the style on the moment the link is clicked.
+
+```
+a:link {
+  color: royalblue;
+}
+
+a:visited {
+  color: green;
+}
+
+a:hover {
+  color: royalblue;
+  background-color:#E6E6FA;
+}
+
+a:active {
+  color: royalblue;
+  background-color:beige;
+}
+```
+
+![test of various styles](https://media.giphy.com/media/l4EoMGejlNnl5ddy8/giphy.gif)
+
+Note that if you want to use `a:hover` and `a:visited` you have to respect the order below (`a:active` is last and `a:hover` always come after `a:link` and `a:visited`). 
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
 
+* [Stylizing Links (MDN)](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Styling_links)
 


### PR DESCRIPTION
**Description**
create sections for simple styling using `color` and the usual links' states (`:link`, `:visited`, `:hover` and `:active`). Also added a link to MDN "stylizing links" page.