### PR TITLE
Fix NavPanel component to maintain order of items regardless if a Panel Item is open or closed

### DIFF
--- a/src/components/LayoutComponents/nav/NavPanel.js
+++ b/src/components/LayoutComponents/nav/NavPanel.js
@@ -68,10 +68,11 @@ class NavPanel extends PureComponent {
   renderBody() {
     const { hasChildren, children, isExpanded } = this.props;
     const childrenWithChildren = children.filter(child => child.props.children);
-    const uniqueChildren = childrenWithChildren.concat(
-      children.filter(
-        child => !childrenWithChildren.some(x => x.key === child.key)
-      )
+    const uniqueChildren = children.filter(
+      child =>
+        !childrenWithChildren.some(
+          (potentialDupe, index) => index > 0 && potentialDupe.key === child.key
+        )
     );
     return (
       <div className={isExpanded ? 'body' : ''}>


### PR DESCRIPTION
Fix NavPanel component to maintain order of items regardless if a Panel Item is open or closed

## ✅️ By submitting this PR, I have verified the following

- [X] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md` since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Other examples are **Git: edit Git Commit article** or **PHP: create PHP section and add Data Structures article**
- [X] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [X] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.