### PR TITLE
Fixes breadcrumb separator character that was not rendering

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -56,7 +56,7 @@
 }
 
 .breadcrumb > li + li:before {
-  content: '\f105';
+  content: '\203A';
   color: #555;
 }
 


### PR DESCRIPTION
Hello! 👋 

This is based on [issue 18064](https://github.com/freeCodeCamp/freeCodeCamp/issues/18064) posted on the [freeCodeCamp repo](https://github.com/freeCodeCamp).

A content value that was supposed to render the breadcrumb separators on the guide was not rendering in production whereas it did appear to do so in development.

The content value for the `.breadcrumb > li + li:before` rule in `main.css` from `\F105` to the right-facing angle quote mark `\203A` was the only change.

I've confirmed that this works in development and production on Chrome and Firefox, and confirmed that it works in development on Safari.

---

## ✅️ By submitting this PR, I have verified the following

- [X] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md` since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Other examples are **Git: edit Git Commit article** or **PHP: create PHP section and add Data Structures article**
- [X] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [X] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.
