### PR TITLE
GIF content length exceeded not displayed. Proposing link fix

### DIFF
--- a/src/pages/machine-learning/deep-learning/index.md
+++ b/src/pages/machine-learning/deep-learning/index.md
@@ -28,9 +28,7 @@ A resnet-152 model looks like this (Don't worry if you don't understand it. It's
 ![Resnet-152 Model](https://adeshpande3.github.io/assets/ResNet.gif)
 
 
-Google had its own neural network architecture that won the Imagenet challenged in 2014:
-
-![GoogLeNet Model](https://adeshpande3.github.io/assets/GoogleNet.gif)
+Google had its own neural network architecture that won the Imagenet challenged in 2014. Which can be seen in a <a href="https://adeshpande3.github.io/assets/GoogleNet.gif">gif here in more detail</a>.
 
 
 ### How to implement your own?


### PR DESCRIPTION
GIF content length exceeded and not displayed in existing version, proposing fix by including a link in text for people to be directed towards.

Replace this sentence with a brief description of the awesome changes your PR has. 😊

---

<!-- Thank you for contributing to the `guides` repo, it is much appreciated! 😊 -->

<!--

Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

-->

## ✅️ By submitting this PR, I have verified the following

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md` since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Other examples are **Git: edit Git Commit article** or **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.

<!-- TO NOTE

1. Avoid a duplicate PR by searching through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes.

2. If you edit a stub article, your changes are substantial enough to justify removing the stub text ("This article is a stub..." part).

We can't accept PRs that only add links to the "More Information" section - a repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file.

3. Your changes must pass the Travis CI build.

Any new folder you create in "src/pages" must have an index.md.

All articles must have the following as the first three lines in the file:

---
title: Article title goes here
---

-->
