### PR TITLE
Correct url in elixir enumerables guide

### DIFF
--- a/src/pages/elixir/enumerables/index.md
+++ b/src/pages/elixir/enumerables/index.md
@@ -23,5 +23,5 @@ iex> Enum.map([5, 10, 15, 20], fn(x) -> x * 2 end)
 ```
 
 #### More Information:
-* [elixir-lang.org | recursion](https://elixir-lang.org/getting-started/recursion.html)
+* [elixir-lang.org | recursion](https://elixir-lang.org/getting-started/enumerables-and-streams.html)
 * [hexdocs | Enum](https://hexdocs.pm/elixir/Enum.html)

--- a/src/pages/elixir/lists/index.md
+++ b/src/pages/elixir/lists/index.md
@@ -3,11 +3,35 @@ title: Lists
 ---
 ## Lists
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/elixir/lists/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+In Elixir, lists are data structures comprised of values within square brackets. The values in a list can be any type.
+```elixir
+iex> [1, "string", true]
+[1, "string", true]
+```
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+## Immutability
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+Data structures in Elixir are immutable, so any operations performed on a List will return a new list, leaving the original intact.
+```elixir
+iex> list = [1, "string", true]
+[1, "string", true]
+iex> list ++ [2]
+[1, "string", true, 2]
+iex> list
+[1, "string", true]
+```
+
+## Heads and Tails
+
+The head (first element) of a list and the tail (remaining values) can easily accessed with the `hd/1` and `tl/1` operators.
+```elixir
+iex> list = [1, "string", true]
+iex> hd(list)
+1
+iex> tl(list)
+["string", true]
+```
 
 #### More Information:
-<!-- Please add any articles you think might be helpful to read before writing the article -->
+* [elixir-lang.org | recursion](https://elixir-lang.org/getting-started/basic-types.html#linked-lists)
+* [hexdocs | Enum](https://hexdocs.pm/elixir/List.html)


### PR DESCRIPTION
Corrected the URL in the Elixir guide for Enumerables

## ✅️ By submitting this PR, I have verified the following

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md` since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Other examples are **Git: edit Git Commit article** or **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.

<!-- TO NOTE

1. Avoid a duplicate PR by searching through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes.

2. If you edit a stub article, your changes are substantial enough to justify removing the stub text ("This article is a stub..." part).

We can't accept PRs that only add links to the "More Information" section - a repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file.

3. Your changes must pass the Travis CI build.

Any new folder you create in "src/pages" must have an index.md.

All articles must have the following as the first three lines in the file:

---
title: Article title goes here
---

-->
