### PR TITLE
Fix to use csharp instead of C# in code blocks

### DIFF
--- a/src/pages/csharp/async-await/index.md
+++ b/src/pages/csharp/async-await/index.md
@@ -15,7 +15,7 @@ To learn more about using the promise model to handle asynchrony, check out this
 ## Examples
 
 1. Submit Form to the Server
-```C#
+```csharp
 private readonly string url = 'http://localhost:3000/api/submit';
 private readonly HttpContent formContent = new HttypContent();
 
@@ -32,7 +32,7 @@ SubmitButton.Clicked += async (object, event) =>
 ```
 
 2. "Latches" Synchronizer
-```C#
+```csharp
 public async Task<int> CalcDamage(Player player)
 {
   // CPU-intense method, calculate afflicted damage done to the


### PR DESCRIPTION
Fix to use csharp instead of C# in code blocks. This should resolve the following issue in the guide.

![image](https://user-images.githubusercontent.com/1869717/46382185-b7f03b80-c65e-11e8-90fa-042f736b1cd5.png)

## ✅️ By submitting this PR, I have verified the following

- [x] Added descriptive name to PR
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate or repetitive content that has been directly copied from another source.

