### PR TITLE
Fixed code format error

### DIFF
--- a/src/pages/angular/pipes/index.md
+++ b/src/pages/angular/pipes/index.md
@@ -87,7 +87,7 @@ On to the class logic. The `PipeTransform` implementation provides the instructi
 
 `value: any` is the output that the pipe receives. Think of `<div>{{ someValue | example }}</div>`. The value of someValue gets passed to the `transform` function’s `value: any` parameter. This is the same `transform` function defined in the ExamplePipe class.
 
-`args?: any` is any argument that the pipe optionally receives. Think of `<div>{{ someValue | example:[some-argument] }}</div>`. `[some-argument]’ can be replace by any one value. This value gets passed to the `transform` function’s `args?: any` parameter. That is, the `transform` function defined in ExamplePipe's class.
+`args?: any` is any argument that the pipe optionally receives. Think of `<div>{{ someValue | example:[some-argument] }}</div>`. `[some-argument]` can be replace by any one value. This value gets passed to the `transform` function’s `args?: any` parameter. That is, the `transform` function defined in ExamplePipe's class.
 
 Whatever the function returns (`return null;`) becomes the output of the pipe operation. Take a look at the next example to see a complete example of ExamplePipe. Depending on the variable the pipe receives, it either uppercases or lowercases the input as new output. An invalid or nonexistent argument will cause the pipe to return the same input as output.
 


### PR DESCRIPTION
There is a bit in the Creating Pipes section where the wrong character was used to end an inline code bit, causing the whole paragraph to go messy and borderline unreadable. This is simply a fix of that.

---

<!-- Thank you for contributing to the `guides` repo. It is much appreciated! 😊 -->

<!--

Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete.

- [x] Like this!

-->

## ✅️ By submitting this PR, I have verified the following:

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md`, since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Additional PR title examples:
    - **Git: edit Git Commit article**
    - **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate, or repetitive content that has been directly copied from another source.

<!-- TO NOTE

1. Avoid a duplicate PR by searching through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes.

2. If you edit a stub article, ensure your changes are substantial enough to justify removing the stub text (the "This article is a stub..." part).

3. We can't accept PRs that only add links to the "More Information" section. A repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file.

4. Your changes must pass the Travis CI build.

5. Any new folder you create in "src/pages" must have an index.md.

6. All articles must have the following as the first three lines in the file:

---
title: Article title goes here
---

-->
