### PR TITLE
Added Developer Code reference link & changed links to Markdown style

### DIFF
--- a/src/pages/wordpress/index.md
+++ b/src/pages/wordpress/index.md
@@ -9,4 +9,5 @@ WordPress is a free and open-source content management system based on PHP and M
 ### More Information
 
 <a href='https://codex.wordpress.org/' target='_blank' rel='nofollow'>WordPress Codex: the online manual</a>
+
 <a href='https://developer.wordpress.org/reference/' target='_blank' rel='nofollow'>WordPress Code Reference</a>

--- a/src/pages/wordpress/index.md
+++ b/src/pages/wordpress/index.md
@@ -8,6 +8,6 @@ WordPress is a free and open-source content management system based on PHP and M
 
 ### More Information
 
-<a href='https://codex.wordpress.org/' target='_blank' rel='nofollow'>WordPress Codex: the online manual</a>
+[WordPress Codex: the online manual](https://codex.wordpress.org/)
 
-<a href='https://developer.wordpress.org/reference/' target='_blank' rel='nofollow'>WordPress Code Reference</a>
+[WordPress Code Reference](https://developer.wordpress.org/reference/)

--- a/src/pages/wordpress/index.md
+++ b/src/pages/wordpress/index.md
@@ -8,4 +8,5 @@ WordPress is a free and open-source content management system based on PHP and M
 
 ### More Information
 
-<a href='https://codex.wordpress.org/' target='_blank' rel='nofollow'>WordPress Codex</a>
+<a href='https://codex.wordpress.org/' target='_blank' rel='nofollow'>WordPress Codex: the online manual</a>
+<a href='https://developer.wordpress.org/reference/' target='_blank' rel='nofollow'>WordPress Code Reference</a>


### PR DESCRIPTION
- Rephrased WordPress Codex title
- Added link to WordPress Developer Code reference
- Changed links from HTML tags to Markdown style - as per [Style Guidline](https://github.com/freeCodeCamp/guide/blob/master/CONTRIBUTING.md#links)