### PR TITLE
Fix: Broken Netlify Build Due to Unscaped Character in `src/pages/css/index.md`

### DIFF
--- a/src/pages/css/index.md
+++ b/src/pages/css/index.md
@@ -1,8 +1,8 @@
 ---
-title: CSS: Cascading Style Sheets
+title: Cascading Style Sheets (CSS)
 ---
 
-### CSS: Cascading Style Sheets
+### Cascading Style Sheets (CSS)
 
 CSS stands for Cascading Style Sheets. It was first invented in 1996, and is now a standard feature of all major web browsers.
 
@@ -15,8 +15,8 @@ You can build some pretty amazing things in CSS alone, such as this pure-CSS [Mi
 ![](https://cdn-images-1.medium.com/max/800/1*GFcKk9KxqHAnWa1ECcKDOQ.png)
 
 #### Suggested Reading:
-A good start is the freeCodeCamp curriculum [Introduction to Basic CSS](https://learn.freecodecamp.org/responsive-web-design/basic-css)
+A good start is the freeCodeCamp curriculum [Introduction to Basic CSS](https://learn.freecodecamp.org/responsive-web-design/basic-css).
 
-Another suggestion for beginners is W3C's <a href='https://www.w3.org/Style/Examples/011/firstcss' target='_blank' rel='nofollow'>Starting with HTML + CSS</a> teaches how to create a style sheet. 
+Another suggestion for beginners is W3C's [Starting with HTML + CSS](https://www.w3.org/Style/Examples/011/firstcss) teaches how to create a style sheet.
 
 The site [CSS Zen Garden](http://www.csszengarden.com/) is a great example how the same html can be styled to look totally unique.


### PR DESCRIPTION
The colon intially introduced in #6367 was breaking Netlify builds presumably because it is unescape. This PR changes the title of the article `src/pages/css/index.md` from "CSS: Cascading Style Sheets" to "Cascading Style Sheets (CSS)". The guide was tested to build (locally) without any errors after this change.

Please feel free to tag this trivial change as `invalid` at your discretion once it has been reviewd/merged.

---

## ✅️ By submitting this PR, I have verified the following:

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md`, since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Additional PR title examples:
    - **Git: edit Git Commit article**
    - **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate, or repetitive content that has been directly copied from another source.
