### PR TITLE
Replace broken link for knights tour image.

### DIFF
--- a/src/pages/algorithms/backtracking-algorithms/index.md
+++ b/src/pages/algorithms/backtracking-algorithms/index.md
@@ -14,7 +14,7 @@ Backtracking is a general algorithm for finding all (or some) solutions to some 
 
  ### Path followed by Knight to cover all the cells
   Following is chessboard with 8 x 8 cells. Numbers in cells indicate move number of Knight.
-  [![chrome_2017-10-21_11-54-32.png](https://s1.postimg.org/3mj9ovlzbz/chrome_2017-10-21_11-54-32.png)](https://postimg.org/image/7657eoop3v/)
+  [![The knight's tour solution - by Euler](https://upload.wikimedia.org/wikipedia/commons/d/df/Knights_tour_%28Euler%29.png)](https://commons.wikimedia.org/wiki/File:Knights_tour_(Euler).png)
 
 ### Naive Algorithm for Knight’s tour
 The Naive Algorithm is to generate all tours one by one and check if the generated tour satisfies the constraints.


### PR DESCRIPTION
The image visualizing the Knight's tour is broken and doesn't display.
Replacing it with an image of Euler's solution on Wikimedia Commons, this should be pretty resistent to link rot.

---

<!-- Thank you for contributing to the `guides` repo. It is much appreciated! 😊 -->

<!--

Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete.

- [x] Like this!

-->

## ✅️ By submitting this PR, I have verified the following:

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md`, since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Additional PR title examples:
    - **Git: edit Git Commit article**
    - **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate, or repetitive content that has been directly copied from another source.

<!-- TO NOTE

1. Avoid a duplicate PR by searching through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes.

2. If you edit a stub article, ensure your changes are substantial enough to justify removing the stub text (the "This article is a stub..." part).

3. We can't accept PRs that only add links to the "More Information" section. A repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file.

4. Your changes must pass the Travis CI build.

5. Any new folder you create in "src/pages" must have an index.md.

6. All articles must have the following as the first three lines in the file:

---
title: Backtracking Algorithms
---

-->
