### PR TITLE
C#: Updated Title from 'Break statement' to 'Arrays' for Array page

### DIFF
--- a/src/pages/csharp/array/index.md
+++ b/src/pages/csharp/array/index.md
@@ -1,5 +1,5 @@
 ---
-title: Break statement
+title: Arrays
 ---
 
 # Arrays


### PR DESCRIPTION
Updated Title for Array page because it had another title in it, causing to hide another page.
