### PR TITLE
Fix spellings referring to request url in code sample

### DIFF
--- a/src/pages/miscellaneous/accessing-the-database-from-your-front-end/index.md
+++ b/src/pages/miscellaneous/accessing-the-database-from-your-front-end/index.md
@@ -7,4 +7,4 @@ You must have noticed in **main.controller.js** how _things_ were retrieved from
         $scope.awesomeThings = awesomeThings;  
     });
 
-What this does is call the api with a "get" request, which is then routed by **/server/api/thing/index.js** to the _exports.index_ function in **thing.controller.js**. You'll also notice in **main.controller.js** that there are included examples of _$http.post_ and _$http.delete_ functions too! How nice!
+What this does is call the api with a "get" request, which is then routed by **/server/api/things/index.js** to the _exports.index_ function in **things.controller.js**. You'll also notice in **main.controller.js** that there are included examples of _$http.post_ and _$http.delete_ functions too! How nice!


### PR DESCRIPTION
Code sample sends Get request to /api/things but text that referenced the request spoke of /api/thing, spelling corrected to remove ambiguity. 😊

---

<!-- Thank you for contributing to the `guides` repo. It is much appreciated! 😊 -->

<!--

Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete.

- [x] Like this!

-->

## ✅️ By submitting this PR, I have verified the following:

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md`, since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Additional PR title examples:
    - **Git: edit Git Commit article**
    - **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate, or repetitive content that has been directly copied from another source.

<!-- TO NOTE

1. Avoid a duplicate PR by searching through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes.

2. If you edit a stub article, ensure your changes are substantial enough to justify removing the stub text (the "This article is a stub..." part).

3. We can't accept PRs that only add links to the "More Information" section. A repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file.

4. Your changes must pass the Travis CI build.

5. Any new folder you create in "src/pages" must have an index.md.

6. All articles must have the following as the first three lines in the file:

---
title: Article title goes here
---

-->
