### PR TITLE
Make format script work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "develop": "gatsby develop",
     "ensure-page-naming": "node ./bin/ensure-page-naming.js",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore . --fix",
-    "format": "prettier --single-quote --semi es5 --write '?(src|plugins)/**/*.js' && npm run lint",
+    "format": "prettier --single-quote --semi es5 --write \"?(src|plugins)/**/*.js\" && npm run lint",
     "pre-commit-message": "echo \"Running pre-commit script. This can take a while.\"",
     "test": "yarn ensure-page-naming && mocha  -R spec \"./{,!(node_modules)/**/}*.test.js\""
   },


### PR DESCRIPTION
Script `format` did not work on Windows.
Replaced `'` with `\"` Was done on `pre-commit-message? and `test` script already.

## ✅️ By submitting this PR, I have verified the following:

- [x] Added descriptive name to PR
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate, or repetitive content that has been directly copied from another source.